### PR TITLE
adding bracket syntax, examples and few runners

### DIFF
--- a/common/build.sbt
+++ b/common/build.sbt
@@ -1,6 +1,5 @@
 import pulse.plugin._
 import pulse.plugin.dependencies._
-import local.dependencies._
 
 libraryDependencies ++= Seq(
   fs2.core,
@@ -9,9 +8,12 @@ libraryDependencies ++= Seq(
   apache.lang,
   log4s.core,
   cats.all,
+  fs2.cats,
   finagle.core,
   _test(scalatest.core)
 )
+
+settings.common
 
 publishing.settings
 

--- a/common/src/main/scala/pulse/common/Managed.scala
+++ b/common/src/main/scala/pulse/common/Managed.scala
@@ -8,5 +8,5 @@ trait Managed[A] {
   /**
    * Release the specified instance
    */
-  def close(instance: A): Unit
+  def close (instance: A): Unit
 }

--- a/common/src/main/scala/pulse/common/Runner.scala
+++ b/common/src/main/scala/pulse/common/Runner.scala
@@ -1,0 +1,35 @@
+package pulse.common
+
+import org.log4s
+import fs2.Task
+
+import logging._
+import syntax._
+
+abstract class Runner {
+
+  private implicit val L = log4s.getLogger
+
+  final def main(args: Array[String]): Unit = run(args.toList).unsafeAttemptRun() match {
+    case Left (f) => L.error(s"Unexpected exception during application run. ${logging.describe(f)}"); System.exit(1)
+    case Right(_) => L.info(s"System has been shutdown successfully")
+  }
+
+  protected def run (args: List[String]): Task[Unit]
+
+}
+
+abstract class ContextRunner[A] extends Runner {
+  import fs2.interop.cats._
+
+  private implicit val L = log4s.getLogger
+
+  protected implicit def managedContext: Managed[A]
+
+  protected def createContext(args: List[String]): Task[A]
+
+  protected def execute(context: A): Task[Unit]
+
+  override protected def run (args: List[String]) = bracket(createContext(args))(execute)
+
+}

--- a/common/src/main/scala/pulse/common/syntax/Resources.scala
+++ b/common/src/main/scala/pulse/common/syntax/Resources.scala
@@ -5,9 +5,16 @@ import pulse.common.Managed
 
 trait Resources {
 
-  def use[A,B,F[_]](instance: A)(body: A => F[B])(implicit M: Monad[F], R: Managed[A], E: MonadError[F, Throwable]) = M.flatMap(E.attempt(body(instance))) {
+  def use[F[_], A,B](instance: A)(body: A => F[B])(implicit M: Monad[F], R: Managed[A], E: MonadError[F, Throwable]) = M.flatMap(E.attempt(body(instance))) {
     case Left (failure) => R.close(instance); E.raiseError[B](failure)
     case Right(content) => R.close(instance); M.pure(content)
   }
+
+  def bracket[F[_], A, B](in: F[A])(b: A => F[B])(implicit M: Monad[F], R: Managed[A], E: MonadError[F, Throwable]) =
+    M.flatMap(E.attempt(in)) {
+      case Left (f) => E.raiseError[B](f)
+      case Right(c) => use(c)(b)
+    }
+
 
 }

--- a/config/build.sbt
+++ b/config/build.sbt
@@ -8,6 +8,8 @@ libraryDependencies ++= Seq(
   _test(scalatest.core)
 )
 
+settings.common
+
 publishing.settings
 
 local.settings

--- a/config/src/main/scala/pulse/config/readers.scala
+++ b/config/src/main/scala/pulse/config/readers.scala
@@ -7,7 +7,7 @@ import fs2.interop.cats._
 
 import common._
 
-object reader {
+object readers {
 
   val conf: ReaderConf[Conf] = Kleisli.ask[Task, Conf]
 

--- a/config/src/test/scala/pulse/config/tests/ReaderSpec.scala
+++ b/config/src/test/scala/pulse/config/tests/ReaderSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, ShouldMatchers}
 import eu.timepit.refined.auto._
 import fs2.interop.cats._
 
-import reader._
+import readers._
 import syntax._
 import typesafe._
 

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -1,0 +1,5 @@
+import pulse.plugin._
+
+settings.common
+
+publishing.ignore

--- a/examples/src/main/scala/pulse/examples/configs/mutable/Main.scala
+++ b/examples/src/main/scala/pulse/examples/configs/mutable/Main.scala
@@ -1,0 +1,42 @@
+package pulse.examples.configs.mutable
+
+import java.io.File
+import org.log4s
+
+import fs2.{Stream, Task}
+import fs2.interop.cats._
+
+import eu.timepit.refined.auto._
+
+import pulse.common.exceptions._
+import pulse.common.logging
+import pulse.common._
+
+import pulse.config.{Conf, Source}
+import pulse.config.typesafe._
+import pulse.config.syntax._
+import pulse.config.readers._
+
+object Main extends Runner {
+
+  implicit val L = log4s.getLogger
+
+  val reader = for {
+    _ <- conf
+    a <- get[String]("config.testA")
+    b <- get[String]("config.testB")
+    s <- subconfig("config.subconfig")
+    c <- s.get[String]("testC")
+  } yield (a,b,c)
+
+  def program(from: File) = for {
+    c <- Conf.mutable(Source.FileSource(from))
+    v <- Stream.eval(reader(c))
+    _ <- Stream.eval(logging.info(s"$v"))
+  } yield ()
+
+  protected def run(args: List[String]): Task[Unit] = args match {
+    case h :: _ => program(new File(h)).run
+    case Nil    => Task.fail(NotSupportedException("filename is required"))
+  }
+}

--- a/project.sbt
+++ b/project.sbt
@@ -10,6 +10,8 @@ lazy val common   = project
 
 lazy val config   = project.dependsOn(common)
 
+lazy val examples = project.dependsOn(config, common)
+
 settings.common
 
 publishing.ignore

--- a/project/local.scala
+++ b/project/local.scala
@@ -4,13 +4,12 @@ import bintray.BintrayKeys._
 import sbt.Keys._
 
 object local {
-  object dependencies {
-    object versions {
-    }
-  }
 
   def settings = Seq(
     bintrayOrganization := Some("impulse-io"),
-    publishMavenStyle := true
+    publishMavenStyle   := true,
+    scalacOptions ++= Seq("-feature")
   )
+
+
 }


### PR DESCRIPTION
 - adding a simple runner and context-aware runner. Context-aware runner is able to dispose its context during last steps of the program
 - adding an examples project 
 - adding an initial reading step to the mutable config reader
 - adding a bracket syntax that is slightly different from `use`. Specifically it works with effectful instance,
 - adding common settings to all build.sbt, as all of them were run without specific compiler options 