### PR TITLE
Support of more types in Typesafe configuration

### DIFF
--- a/config/src/main/scala/pulse/config/TypeDescriptor.scala
+++ b/config/src/main/scala/pulse/config/TypeDescriptor.scala
@@ -14,6 +14,9 @@ trait DescriptorValue extends Product with Serializable
 object Values {
   case object String  extends DescriptorValue
   case object Int     extends DescriptorValue
+  case object Double  extends DescriptorValue
+  case object Boolean extends DescriptorValue
+  case object Long    extends DescriptorValue
   case object Unknown extends DescriptorValue
 }
 

--- a/config/src/main/scala/pulse/config/TypeDescriptor.scala
+++ b/config/src/main/scala/pulse/config/TypeDescriptor.scala
@@ -12,11 +12,18 @@ trait TypeDescriptor[T] {
 trait DescriptorValue extends Product with Serializable
 
 object Values {
-  case object String  extends DescriptorValue
-  case object Int     extends DescriptorValue
-  case object Double  extends DescriptorValue
-  case object Boolean extends DescriptorValue
-  case object Long    extends DescriptorValue
-  case object Unknown extends DescriptorValue
+  case object String      extends DescriptorValue
+  case object Int         extends DescriptorValue
+  case object Double      extends DescriptorValue
+  case object Boolean     extends DescriptorValue
+  case object Long        extends DescriptorValue
+  case object AnyRef      extends DescriptorValue
+  case object StringList  extends DescriptorValue
+  case object IntList     extends DescriptorValue
+  case object DoubleList  extends DescriptorValue
+  case object BooleanList extends DescriptorValue
+  case object LongList    extends DescriptorValue
+  case object AnyRefList  extends DescriptorValue
+  case object Unknown     extends DescriptorValue
 }
 

--- a/config/src/main/scala/pulse/config/syntax/Descriptors.scala
+++ b/config/src/main/scala/pulse/config/syntax/Descriptors.scala
@@ -11,4 +11,10 @@ trait Descriptors {
 
   implicit val integerDescriptor: TypeDescriptor[Int]   = map[Int](Values.Int)
 
+  implicit val doubleDescriptor: TypeDescriptor[Double] = map[Double](Values.Double)
+
+  implicit val booleanDescriptor: TypeDescriptor[Boolean] = map[Boolean](Values.Boolean)
+
+  implicit val longDescriptor: TypeDescriptor[Long] = map[Long](Values.Long)
+
 }

--- a/config/src/main/scala/pulse/config/syntax/Descriptors.scala
+++ b/config/src/main/scala/pulse/config/syntax/Descriptors.scala
@@ -17,4 +17,18 @@ trait Descriptors {
 
   implicit val longDescriptor: TypeDescriptor[Long] = map[Long](Values.Long)
 
+  implicit val anyRefDescriptor: TypeDescriptor[AnyRef] = map[AnyRef](Values.AnyRef)
+
+  implicit val stringListDescriptor: TypeDescriptor[Seq[String]] = map[Seq[String]](Values.StringList)
+
+  implicit val integerListDescriptor: TypeDescriptor[Seq[Int]]   = map[Seq[Int]](Values.IntList)
+
+  implicit val doubleListDescriptor: TypeDescriptor[Seq[Double]] = map[Seq[Double]](Values.DoubleList)
+
+  implicit val booleanListDescriptor: TypeDescriptor[Seq[Boolean]] = map[Seq[Boolean]](Values.BooleanList)
+
+  implicit val longListDescriptor: TypeDescriptor[Seq[Long]] = map[Seq[Long]](Values.LongList)
+
+  implicit val anyRefListDescriptor: TypeDescriptor[Seq[AnyRef]] = map[Seq[AnyRef]](Values.AnyRefList)
+
 }

--- a/config/src/main/scala/pulse/config/typesafe/TypesafeConf.scala
+++ b/config/src/main/scala/pulse/config/typesafe/TypesafeConf.scala
@@ -1,6 +1,8 @@
 package pulse.config
 package typesafe
 
+import scala.collection.JavaConverters._
+
 import com.typesafe.config.Config
 import fs2.Task
 
@@ -17,6 +19,13 @@ final class TypesafeConf(self: Config) extends Conf {
     case (_, Values.Double)     => delay { self.getDouble(path).asInstanceOf[T] }
     case (_, Values.Long)       => delay { self.getLong(path).asInstanceOf[T] }
     case (_, Values.Boolean)    => delay { self.getBoolean(path).asInstanceOf[T] }
+    case (_, Values.AnyRef)     => delay { self.getAnyRef(path).asInstanceOf[T] }
+    case (_, Values.StringList)     => delay { self.getStringList(path).asScala.asInstanceOf[T] }
+    case (_, Values.IntList)        => delay { self.getIntList(path).asScala.asInstanceOf[T] }
+    case (_, Values.DoubleList)     => delay { self.getDoubleList(path).asScala.asInstanceOf[T] }
+    case (_, Values.LongList)       => delay { self.getLongList(path).asScala.asInstanceOf[T] }
+    case (_, Values.BooleanList)    => delay { self.getBooleanList(path).asScala.asInstanceOf[T] }
+    case (_, Values.AnyRefList)     => delay { self.getAnyRefList(path).asScala.asInstanceOf[T] }
     case (_, Values.Unknown)    => fail(ConfigException(s"Unable to recognize value for extraction"))
   }
 
@@ -27,6 +36,13 @@ final class TypesafeConf(self: Config) extends Conf {
     case (_, Values.Double)     => delay { Option(self.getDouble(path)).map(_.asInstanceOf[T]) }
     case (_, Values.Long)       => delay { Option(self.getLong(path)).map(_.asInstanceOf[T]) }
     case (_, Values.Boolean)    => delay { Option(self.getBoolean(path)).map(_.asInstanceOf[T]) }
+    case (_, Values.AnyRef)     => delay { Option(self.getAnyRef(path)).map(_.asInstanceOf[T]) }
+    case (_, Values.StringList)     => delay { Option(self.getStringList(path).asScala).map(_.asInstanceOf[T]) }
+    case (_, Values.IntList)        => delay { Option(self.getIntList(path).asScala).map(_.asInstanceOf[T]) }
+    case (_, Values.DoubleList)     => delay { Option(self.getDoubleList(path).asScala).map(_.asInstanceOf[T]) }
+    case (_, Values.LongList)       => delay { Option(self.getLongList(path).asScala).map(_.asInstanceOf[T]) }
+    case (_, Values.BooleanList)    => delay { Option(self.getBooleanList(path).asScala).map(_.asInstanceOf[T]) }
+    case (_, Values.AnyRefList)     => delay { Option(self.getAnyRefList(path).asScala).map(_.asInstanceOf[T]) }
     case (_, Values.Unknown)    => fail(ConfigException(s"Unable to recognize value for extraction"))
   }
 

--- a/config/src/main/scala/pulse/config/typesafe/TypesafeConf.scala
+++ b/config/src/main/scala/pulse/config/typesafe/TypesafeConf.scala
@@ -14,6 +14,9 @@ final class TypesafeConf(self: Config) extends Conf {
     case (exists, _) if !exists => fail(ConfigException(s"Unable to locate path '$path' in the configuration"))
     case (_, Values.String)     => delay { self.getString(path).asInstanceOf[T] }
     case (_, Values.Int)        => delay { self.getInt(path).asInstanceOf[T] }
+    case (_, Values.Double)     => delay { self.getDouble(path).asInstanceOf[T] }
+    case (_, Values.Long)       => delay { self.getLong(path).asInstanceOf[T] }
+    case (_, Values.Boolean)    => delay { self.getBoolean(path).asInstanceOf[T] }
     case (_, Values.Unknown)    => fail(ConfigException(s"Unable to recognize value for extraction"))
   }
 
@@ -21,6 +24,9 @@ final class TypesafeConf(self: Config) extends Conf {
     case (exists, _) if !exists => now(None)
     case (_, Values.String)     => delay { Option(self.getString(path)).map(_.asInstanceOf[T]) }
     case (_, Values.Int)        => delay { Option(self.getInt(path)).map(_.asInstanceOf[T]) }
+    case (_, Values.Double)     => delay { Option(self.getDouble(path)).map(_.asInstanceOf[T]) }
+    case (_, Values.Long)       => delay { Option(self.getLong(path)).map(_.asInstanceOf[T]) }
+    case (_, Values.Boolean)    => delay { Option(self.getBoolean(path)).map(_.asInstanceOf[T]) }
     case (_, Values.Unknown)    => fail(ConfigException(s"Unable to recognize value for extraction"))
   }
 

--- a/config/src/test/scala/pulse/config/tests/GetSpec.scala
+++ b/config/src/test/scala/pulse/config/tests/GetSpec.scala
@@ -1,0 +1,136 @@
+package pulse.config
+package tests
+
+import org.scalatest.{FlatSpec, ShouldMatchers}
+import eu.timepit.refined.auto._
+import fs2.interop.cats._
+
+import readers._
+import syntax._
+import typesafe._
+
+class GetSpec extends FlatSpec with ShouldMatchers {
+
+  "config reader" should "read all value classes supported by Config" in {
+
+    val testValueInt = 120
+    val testValueDouble = 0.250
+    val testValueLong = 10L
+    val testValueBoolean = true
+
+    val section = for {
+      _ <- conf
+      int <- get[Int]("config.testInt")
+      double <- get[Double]("config.testDouble")
+      long <- get[Long]("config.testLong")
+      bool <- get[Boolean]("config.testBoolean")
+    } yield (int, double, long, bool)
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testInt = $testValueInt
+         |     testDouble = $testValueDouble
+         |     testLong = $testValueLong
+         |     testBoolean = $testValueBoolean
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (int, double, long, bool) =>
+        int  shouldBe testValueInt
+        double shouldBe testValueDouble
+        long  shouldBe testValueLong
+        bool  shouldBe testValueBoolean
+    }
+  }
+
+  it should "read all reference classes supported by Config" in {
+
+    val testValueA = "testValueA"
+    val testValueB = "testValueB"
+
+    val section = for {
+      _ <- conf
+      a <- get[String]("config.testA")
+      b <- get[AnyRef]("config.testB")
+    } yield a -> b
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testA = "$testValueA"
+         |     testB = "$testValueB"
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (left, right) =>
+        left  shouldBe testValueA
+        right shouldBe testValueB
+    }
+  }
+
+  it should "read all lists supported by Config" in {
+
+    val testValueStringList = List("hello", "world")
+    val testValueAnyRefList = List("any", "ref")
+    val testValueIntList = List(120, 130)
+    val testValueDoubleList = List(0.250, 0.350)
+    val testValueLongList = List(10L, 20L)
+    val testValueBooleanList = List(true, false)
+
+    val section = for {
+      _ <- conf
+      strings <- get[Seq[String]]("config.testStringList")
+      anyRefs <- get[Seq[AnyRef]]("config.testAnyRefList")
+      ints <- get[Seq[Int]]("config.testIntList")
+      doubles <- get[Seq[Double]]("config.testDoubleList")
+      longs <- get[Seq[Long]]("config.testLongList")
+      bools <- get[Seq[Boolean]]("config.testBooleanList")
+    } yield (strings, anyRefs, ints, doubles, longs, bools)
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testStringList = ${testValueStringList.mkString("[",",","]")}
+         |     testAnyRefList = ${testValueAnyRefList.mkString("[",",","]")}
+         |     testIntList = ${testValueIntList.mkString("[",",","]")}
+         |     testDoubleList = ${testValueDoubleList.mkString("[",",","]")}
+         |     testLongList = ${testValueLongList.mkString("[",",","]")}
+         |     testBooleanList = ${testValueBooleanList.mkString("[",",","]")}
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (strings, anyRefs, ints, doubles, longs, bools) =>
+        strings  shouldBe testValueStringList
+        anyRefs  shouldBe testValueAnyRefList
+        ints  shouldBe testValueIntList
+        doubles shouldBe testValueDoubleList
+        longs  shouldBe testValueLongList
+        bools  shouldBe testValueBooleanList
+    }
+  }
+
+  it should "correctly process absent values" in {
+
+    val section = for {
+      _ <- conf
+      a <- get[String]("config.testNone")
+    } yield a
+
+    val caught =
+      intercept[pulse.common.exceptions.ConfigException] {
+        (section =<< Conf.immutable(Source.Raw("config{}"))).unsafeRun()
+      }
+
+    caught.getMessage shouldBe "Unable to locate path 'config.testNone' in the configuration"
+  }
+}

--- a/config/src/test/scala/pulse/config/tests/LookupSpec.scala
+++ b/config/src/test/scala/pulse/config/tests/LookupSpec.scala
@@ -1,0 +1,132 @@
+package pulse.config
+package tests
+
+import cats.data.Kleisli
+import org.scalatest.{FlatSpec, ShouldMatchers}
+import eu.timepit.refined.auto._
+import fs2.Task
+import fs2.interop.cats._
+import readers._
+import syntax._
+import typesafe._
+
+class LookupSpec extends FlatSpec with ShouldMatchers {
+
+  "config reader" should "read all value classes supported by Config" in {
+
+    val testValueInt = 120
+    val testValueDouble = 0.250
+    val testValueLong = 10L
+    val testValueBoolean = true
+
+    val section = for {
+      _ <- conf
+      int <- lookup[Int]("config.testInt")
+      double <- lookup[Double]("config.testDouble")
+      long <- lookup[Long]("config.testLong")
+      bool <- lookup[Boolean]("config.testBoolean")
+    } yield (int, double, long, bool)
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testInt = $testValueInt
+         |     testDouble = $testValueDouble
+         |     testLong = $testValueLong
+         |     testBoolean = $testValueBoolean
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (int, double, long, bool) =>
+        int  shouldBe Some(testValueInt)
+        double shouldBe Some(testValueDouble)
+        long  shouldBe Some(testValueLong)
+        bool  shouldBe Some(testValueBoolean)
+    }
+  }
+
+  it should "read all reference classes supported by Config" in {
+
+    val testValueA = "testValueA"
+    val testValueB = "testValueB"
+
+    val section = for {
+      _ <- conf
+      a <- lookup[String]("config.testA")
+      b <- lookup[AnyRef]("config.testB")
+    } yield a -> b
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testA = "$testValueA"
+         |     testB = "$testValueB"
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (left, right) =>
+        left  shouldBe Some(testValueA)
+        right shouldBe Some(testValueB)
+    }
+  }
+
+  it should "read all lists supported by Config" in {
+
+    val testValueStringList = List("hello", "world")
+    val testValueAnyRefList = List("any", "ref")
+    val testValueIntList = List(120, 130)
+    val testValueDoubleList = List(0.250, 0.350)
+    val testValueLongList = List(10L, 20L)
+    val testValueBooleanList = List(true, false)
+
+    val section = for {
+      _ <- conf
+      strings <- lookup[Seq[String]]("config.testStringList")
+      anyRefs <- lookup[Seq[AnyRef]]("config.testAnyRefList")
+      ints <- lookup[Seq[Int]]("config.testIntList")
+      doubles <- lookup[Seq[Double]]("config.testDoubleList")
+      longs <- lookup[Seq[Long]]("config.testLongList")
+      bools <- lookup[Seq[Boolean]]("config.testBooleanList")
+    } yield (strings, anyRefs, ints, doubles, longs, bools)
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testStringList = ${testValueStringList.mkString("[",",","]")}
+         |     testAnyRefList = ${testValueAnyRefList.mkString("[",",","]")}
+         |     testIntList = ${testValueIntList.mkString("[",",","]")}
+         |     testDoubleList = ${testValueDoubleList.mkString("[",",","]")}
+         |     testLongList = ${testValueLongList.mkString("[",",","]")}
+         |     testBooleanList = ${testValueBooleanList.mkString("[",",","]")}
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (strings, anyRefs, ints, doubles, longs, bools) =>
+        strings  shouldBe Some(testValueStringList)
+        anyRefs  shouldBe Some(testValueAnyRefList)
+        ints  shouldBe Some(testValueIntList)
+        doubles shouldBe Some(testValueDoubleList)
+        longs  shouldBe Some(testValueLongList)
+        bools  shouldBe Some(testValueBooleanList)
+    }
+  }
+
+  it should "correctly process absent values" in {
+
+    val section = for {
+      _ <- conf
+      a <- lookup[String]("config.testNone")
+    } yield a
+
+    (section =<< Conf.immutable(Source.Raw("config{}"))).unsafeRun() shouldBe None
+  }
+}

--- a/config/src/test/scala/pulse/config/tests/ReaderSpec.scala
+++ b/config/src/test/scala/pulse/config/tests/ReaderSpec.scala
@@ -39,42 +39,6 @@ class ReaderSpec extends FlatSpec with ShouldMatchers {
     }
   }
 
-  it should "read all value classes supported by Config" in {
-
-    val testValueInt = 120
-    val testValueDouble = 0.250
-    val testValueLong = 10L
-    val testValueBoolean = true
-
-    val section = for {
-      _ <- conf
-      int <- get[Int]("config.testInt")
-      double <- get[Double]("config.testDouble")
-      long <- get[Long]("config.testLong")
-      bool <- get[Boolean]("config.testBoolean")
-    } yield (int, double, long, bool)
-
-    val config =
-      s"""
-         |{
-         |   config {
-         |     testInt = $testValueInt
-         |     testDouble = $testValueDouble
-         |     testLong = $testValueLong
-         |     testBoolean = $testValueBoolean
-         |   }
-         |}
-      """.stripMargin
-
-    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
-      case (int, double, long, bool) =>
-        int  shouldBe testValueInt
-        double shouldBe testValueDouble
-        long  shouldBe testValueLong
-        bool  shouldBe testValueBoolean
-    }
-  }
-
   it should "pick up nested sections" in {
 
     val testValueA = "testValueA"

--- a/config/src/test/scala/pulse/config/tests/ReaderSpec.scala
+++ b/config/src/test/scala/pulse/config/tests/ReaderSpec.scala
@@ -39,6 +39,42 @@ class ReaderSpec extends FlatSpec with ShouldMatchers {
     }
   }
 
+  it should "read all value classes supported by Config" in {
+
+    val testValueInt = 120
+    val testValueDouble = 0.250
+    val testValueLong = 10L
+    val testValueBoolean = true
+
+    val section = for {
+      _ <- conf
+      int <- get[Int]("config.testInt")
+      double <- get[Double]("config.testDouble")
+      long <- get[Long]("config.testLong")
+      bool <- get[Boolean]("config.testBoolean")
+    } yield (int, double, long, bool)
+
+    val config =
+      s"""
+         |{
+         |   config {
+         |     testInt = $testValueInt
+         |     testDouble = $testValueDouble
+         |     testLong = $testValueLong
+         |     testBoolean = $testValueBoolean
+         |   }
+         |}
+      """.stripMargin
+
+    (section =<< Conf.immutable(Source.Raw(config))).unsafeRun() match {
+      case (int, double, long, bool) =>
+        int  shouldBe testValueInt
+        double shouldBe testValueDouble
+        long  shouldBe testValueLong
+        bool  shouldBe testValueBoolean
+    }
+  }
+
   it should "pick up nested sections" in {
 
     val testValueA = "testValueA"


### PR DESCRIPTION
Now supported:
String     Int      Double      Boolean     Long        AnyRef      
StringList  IntList     DoubleList  BooleanList      LongList    AnyRefList  

There are more supported by Typesafe Config. For instance:
Number(List), Duration(List), Enum(List), MemorySize(List), Object(List), Config(List)
Is support of these should also be added?

https://typesafehub.github.io/config/latest/api/com/typesafe/config/Config.html

